### PR TITLE
Add example usage script

### DIFF
--- a/example_usage.py
+++ b/example_usage.py
@@ -1,0 +1,16 @@
+"""示範如何使用 stage_light 模組。"""
+from stage_light import StageLight, light_on, light_off
+
+
+def demo():
+    """簡易展示開關燈的流程"""
+    light_on()
+    light_off()
+
+    light = StageLight()
+    light.on()
+    light.off()
+
+
+if __name__ == "__main__":
+    demo()

--- a/git_basics.md
+++ b/git_basics.md
@@ -1,0 +1,27 @@
+# Git 基礎指令
+
+以下提供一個簡易範例，協助初學者了解如何在本地端操作 Git 與 GitHub：
+
+1. **取得程式碼**
+   ```bash
+   git clone <倉庫網址>
+   cd TESTCODEX
+   ```
+2. **建立分支並開始開發**
+   ```bash
+   git checkout -b my-feature
+   # 編輯或新增檔案...
+   ```
+3. **查看與提交變更**
+   ```bash
+   git status        # 檢查變更
+   git add <檔名>    # 將檔案加入暫存區
+   git commit -m "新增功能"
+   ```
+4. **推送到 GitHub 並建立 Pull Request**
+   ```bash
+   git push origin my-feature
+   ```
+   接著在 GitHub 網站上建立 PR，等待審查與合併。
+
+透過上述流程，你可以將自己的修改同步到 GitHub，並與他人協作。

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,47 @@
-# mainline change
+# TESTCODEX 範例專案
+
+這個倉庫用來示範在 GitHub 上進行版本控制與簡單 Python 程式開發。
+內容包含幾個練習腳本，以及一個互動式的小型遊戲《鐵達尼號》。
+
+## 如何執行
+
+1. **舞台燈光模組**
+
+   `stage_light.py` 提供 `light_on()` 與 `light_off()` 兩個函式，以及 `StageLight` 類別，示範如何管理狀態：
+
+   ```python
+   from stage_light import light_on, light_off, StageLight
+
+   light_on()      # 直接開啟燈光
+   light_off()     # 直接關閉燈光
+
+   light = StageLight()
+   light.on()      # 以物件方式操作
+   light.off()
+   ```
+
+2. **鐵達尼號遊戲**
+
+   執行下列指令即可啟動互動劇情：
+
+   ```bash
+   python 鐵達尼號.py
+   ```
+
+   遊戲會引導你選擇角色，並進行十回合的事件選擇，最終計算生還率與結局。
+
+3. **範例腳本**
+
+   執行 `example_usage.py` 可以快速了解舞台燈光模組的用法：
+
+   ```bash
+   python example_usage.py
+   ```
+
+此 README 會在更新後顯示於 GitHub 頁面，方便你重新整理查看變更。
+
+## Git 使用指南
+
+若你想親自嘗試提交程式碼，可以閱讀 `git_basics.md`，其中整理了常見的 Git 操作流程，
+包含如何建立分支、提交變更以及推送至 GitHub 建立 Pull Request。
+

--- a/stage_light.py
+++ b/stage_light.py
@@ -1,3 +1,35 @@
-# TODO: 調整舞台燈光模組
-def light_on(): print('Lights on')
-def light_off(): print('Lights off')
+# 簡易舞台燈光模組，用於示範 Python 函式與狀態管理
+
+_light_state = False  # 追蹤目前燈光狀態
+
+def light_on():
+    """開啟舞台燈光。如果燈已經開啟則不重複輸出。"""
+    global _light_state
+    if not _light_state:
+        print('Lights on')
+        _light_state = True
+
+def light_off():
+    """關閉舞台燈光。如果燈已經關閉則不重複輸出。"""
+    global _light_state
+    if _light_state:
+        print('Lights off')
+        _light_state = False
+
+class StageLight:
+    """可重複使用的舞台燈光控制類別。"""
+
+    def __init__(self):
+        self.is_on = False
+
+    def on(self):
+        """開啟燈光"""
+        if not self.is_on:
+            print('Lights on')
+            self.is_on = True
+
+    def off(self):
+        """關閉燈光"""
+        if self.is_on:
+            print('Lights off')
+            self.is_on = False


### PR DESCRIPTION
## Summary
- add `example_usage.py` to demonstrate stage_light module
- document example script usage in README

## Testing
- `python -m py_compile stage_light.py example_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_68411093dd08832a95d90b9c9a4fec38